### PR TITLE
Add external indicator variables endpoint and integrate on UI

### DIFF
--- a/src/main/java/com/example/demo/controllers/VariableController.java
+++ b/src/main/java/com/example/demo/controllers/VariableController.java
@@ -3,7 +3,6 @@ package com.example.demo.controllers;
 
 import com.example.demo.entity.Variable;
 import com.example.demo.service.VariableService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,11 +11,19 @@ import java.util.List;
 @RequestMapping("/api/variables")
 public class VariableController {
 
-    @Autowired
-    private VariableService variableService;
+    private final VariableService variableService;
+
+    public VariableController(VariableService variableService) {
+        this.variableService = variableService;
+    }
 
     @GetMapping
     public List<Variable> getAllVariables() {
         return variableService.getAllVariables();
+    }
+
+    @GetMapping("/extendidas")
+    public List<Variable> getAllVariablesExtendidas() {
+        return variableService.getAllVariablesWithIndicadores();
     }
 }

--- a/src/main/java/com/example/demo/service/VariableService.java
+++ b/src/main/java/com/example/demo/service/VariableService.java
@@ -2,18 +2,189 @@ package com.example.demo.service;
 
 import com.example.demo.entity.Variable;
 import com.example.demo.repository.VariableRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
 
 @Service
 public class VariableService {
 
-    @Autowired
-    private VariableRepository variableRepository;
+    private static final Logger LOGGER = LoggerFactory.getLogger(VariableService.class);
+    private final VariableRepository variableRepository;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String indicadoresEndpoint;
+
+    public VariableService(
+            VariableRepository variableRepository,
+            RestTemplateBuilder restTemplateBuilder,
+            ObjectMapper objectMapper,
+            @Value("${app.indicadores.ultima-url:http://10.109.1.13:3001/api/indicadores/ultima}") String indicadoresEndpoint
+    ) {
+        this.variableRepository = variableRepository;
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .build();
+        this.objectMapper = objectMapper;
+        this.indicadoresEndpoint = indicadoresEndpoint;
+    }
 
     public List<Variable> getAllVariables() {
         return variableRepository.findAll();
+    }
+
+    public List<Variable> getAllVariablesWithIndicadores() {
+        List<Variable> variables = new ArrayList<>(variableRepository.findAll());
+        variables.addAll(fetchExternalIndicatorVariables());
+        return variables;
+    }
+
+    private List<Variable> fetchExternalIndicatorVariables() {
+        try {
+            String payload = restTemplate.getForObject(indicadoresEndpoint, String.class);
+            if (!StringUtils.hasText(payload)) {
+                return Collections.emptyList();
+            }
+
+            JsonNode root = objectMapper.readTree(payload);
+            JsonNode itemsNode = resolveItemsNode(root);
+            if (itemsNode == null || !itemsNode.isArray()) {
+                return Collections.emptyList();
+            }
+
+            List<Variable> externalVariables = new ArrayList<>();
+            for (JsonNode node : itemsNode) {
+                Variable variable = mapExternalIndicator(node);
+                if (variable != null) {
+                    externalVariables.add(variable);
+                }
+            }
+            return externalVariables;
+        } catch (Exception ex) {
+            LOGGER.warn("No fue posible obtener variables externas desde {}", indicadoresEndpoint, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private JsonNode resolveItemsNode(JsonNode root) {
+        if (root == null) {
+            return null;
+        }
+        if (root.isArray()) {
+            return root;
+        }
+
+        for (String key : List.of("data", "results", "indicadores", "items")) {
+            JsonNode candidate = getCaseInsensitive(root, key);
+            if (candidate != null && candidate.isArray()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private Variable mapExternalIndicator(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+
+        Variable variable = new Variable();
+
+        String remoteId = firstTextValue(node, "idVar", "idVariable", "id", "clave", "codigo", "cve");
+        if (!StringUtils.hasText(remoteId)) {
+            remoteId = UUID.randomUUID().toString();
+        }
+        variable.setIdVar("ext-" + remoteId.replaceAll("\\s+", "-").toLowerCase(Locale.ROOT));
+
+        String idPp = firstTextValue(node, "idPp", "idProceso", "proceso", "processId", "id_pp", "idPP");
+        variable.setIdPp(StringUtils.hasText(idPp) ? idPp : "EXT_IND");
+
+        String varAsig = firstTextValue(node, "varAsig", "nombreIndicador", "nombre", "titulo", "nombreVariable");
+        if (!StringUtils.hasText(varAsig)) {
+            varAsig = "Indicador importado";
+        }
+        variable.setVarAsig(varAsig);
+
+        String nomVar = firstTextValue(node, "nomVar", "nombreFuente", "nombreVariable", "nombreIndicador");
+        variable.setNomVar(StringUtils.hasText(nomVar) ? nomVar : varAsig);
+
+        String tipoVar = firstTextValue(node, "tipoVar", "tipoIndicador", "tipo");
+        variable.setTipoVar(StringUtils.hasText(tipoVar) ? tipoVar : "Indicador externo");
+
+        variable.setCodIdenVar(firstTextValue(node, "codIdenVar", "clave", "codigo", "cveIndicador"));
+        variable.setPregLit(firstTextValue(node, "pregLit", "pregunta", "descripcionValor", "definicionVariables"));
+        variable.setTema(firstTextValue(node, "tema", "tema1", "temaPrincipal"));
+        variable.setSubtema(firstTextValue(node, "subtema", "subTema", "subtema1"));
+        variable.setTema2(firstTextValue(node, "tema2", "temaSecundario"));
+        variable.setSubtema2(firstTextValue(node, "subtema2", "subtemaSecundario"));
+        variable.setCategoria(firstTextValue(node, "categoria", "categoriaIndicador", "clasificacion"));
+
+        String definicion = firstTextValue(node, "defVar", "descripcion", "descripcionCorta", "definicion", "descripcionIndicador");
+        variable.setDefVar(StringUtils.hasText(definicion) ? definicion : "Sin descripción disponible para este indicador externo.");
+
+        String relTab = firstTextValue(node, "relTab", "relacionTablero");
+        variable.setRelTab(StringUtils.hasText(relTab) ? relTab : "No");
+
+        String relMicro = firstTextValue(node, "relMicro", "relacionMicrodato");
+        variable.setRelMicro(StringUtils.hasText(relMicro) ? relMicro : "No");
+
+        String alinMdea = firstTextValue(node, "alinMdea", "alineacionMdea");
+        variable.setAlinMdea(StringUtils.hasText(alinMdea) ? alinMdea : "No aplica");
+
+        String alinOds = firstTextValue(node, "alinOds", "alineacionOds");
+        variable.setAlinOds(StringUtils.hasText(alinOds) ? alinOds : "No aplica");
+
+        String comentarios = firstTextValue(node, "comentVar", "notas", "observaciones", "comentarios");
+        variable.setComentVar(StringUtils.hasText(comentarios) ? comentarios : "Información importada desde el servicio de indicadores externos.");
+
+        return variable;
+    }
+
+    private String firstTextValue(JsonNode node, String... keys) {
+        for (String key : keys) {
+            JsonNode candidate = getCaseInsensitive(node, key);
+            if (candidate != null && !candidate.isNull()) {
+                String value = candidate.asText();
+                if (StringUtils.hasText(value)) {
+                    return value.trim();
+                }
+            }
+        }
+        return "";
+    }
+
+    private JsonNode getCaseInsensitive(JsonNode node, String key) {
+        if (node == null || !StringUtils.hasText(key)) {
+            return null;
+        }
+
+        JsonNode direct = node.get(key);
+        if (direct != null && !direct.isMissingNode()) {
+            return direct;
+        }
+
+        Iterator<String> fieldNames = node.fieldNames();
+        while (fieldNames.hasNext()) {
+            String field = fieldNames.next();
+            if (field.equalsIgnoreCase(key)) {
+                return node.get(field);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.datasource.username=postgres
 spring.datasource.password=nuevo_pass
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+app.indicadores.ultima-url=http://10.109.1.13:3001/api/indicadores/ultima
+
 
 # Configuración JPA/Hibernate
 spring.jpa.database=postgresql

--- a/src/main/resources/static/SIRNyMA/js/variables.js
+++ b/src/main/resources/static/SIRNyMA/js/variables.js
@@ -1,3 +1,5 @@
+const VARIABLES_API_ENDPOINT = "/api/variables/extendidas";
+
 document.addEventListener("DOMContentLoaded", function () {
   // Elementos del DOM
   const searchForm = document.getElementById("searchForm");
@@ -12,6 +14,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const sortSelect = document.getElementById("sortOptions");
   const alinMdeaCheckbox = document.getElementById("alinMdeaCheckbox");
   const alinOdsCheckbox = document.getElementById("alinOdsCheckbox");
+  const loader = document.getElementById("loader");
+  const mainContent = document.getElementById("mainContent");
 
   // Variables globales
   const params = new URLSearchParams(window.location.search);
@@ -176,7 +180,7 @@ searchForm?.addEventListener("submit", function (e) {
 // 🔁 Cargar procesos y variables en paralelo
 Promise.all([
   fetch("/api/proceso").then(res => res.json()),
-  fetch("/api/variables").then(res => res.json())
+  fetch(VARIABLES_API_ENDPOINT).then(res => res.json())
 ])
   .then(([procesos, variables]) => {
     procesosGlobal = procesos;
@@ -421,7 +425,20 @@ function renderSelectedTags(selectedOptions) {
     // Función para cargar todos los elementos al entrar a la página
     async function loadAllVariables() {
     try {
-        const response = await fetch('/api/variables');
+        if (loader) {
+            loader.style.display = "flex";
+        }
+        if (mainContent) {
+            mainContent.style.display = "none";
+        }
+        if (container) {
+            container.innerHTML = "";
+        }
+        if (paginationContainer) {
+            paginationContainer.innerHTML = "";
+        }
+
+        const response = await fetch(VARIABLES_API_ENDPOINT);
         const data = await response.json();
         allData = data;
         currentFilteredData = [...allData];
@@ -437,6 +454,13 @@ function renderSelectedTags(selectedOptions) {
     } catch (error) {
         console.error('Error al cargar los datos:', error);
         container.innerHTML = "<p class='text-center text-danger'>Ocurrió un error al cargar los datos. Inténtalo nuevamente.</p>";
+    } finally {
+        if (loader) {
+            loader.style.display = "none";
+        }
+        if (mainContent) {
+            mainContent.style.display = "";
+        }
     }
 }
 
@@ -497,7 +521,7 @@ let fuentesGlobal = [];
 
 Promise.all([
   fetch('/api/proceso').then(r => r.json()),
-  fetch('/api/variables').then(r => r.json()),
+  fetch(VARIABLES_API_ENDPOINT).then(r => r.json()),
   fetch('/api/microdatos').then(r => r.json()),
   fetch('/api/fuente').then(r => r.json()) // tabla "fuente" con anioEvento, idPp, ligaFuente/ligas
 ]).then(([procesos, variables, microdatos, fuentes]) => {
@@ -1393,7 +1417,7 @@ fetch('/api/clasificaciones')
       .then(res => res.json())
       .then(eventos => {
         eventosGlobal = eventos;
-        fetch('/api/variables')
+        fetch(VARIABLES_API_ENDPOINT)
           .then(res => res.json())
           .then(variables => {
             (variables, 1);

--- a/src/main/resources/static/SIRNyMA/js/variables.js
+++ b/src/main/resources/static/SIRNyMA/js/variables.js
@@ -424,45 +424,48 @@ function renderSelectedTags(selectedOptions) {
 
     // Función para cargar todos los elementos al entrar a la página
     async function loadAllVariables() {
-    try {
-        if (loader) {
-            loader.style.display = "flex";
-        }
-        if (mainContent) {
-            mainContent.style.display = "none";
-        }
-        if (container) {
-            container.innerHTML = "";
-        }
-        if (paginationContainer) {
-            paginationContainer.innerHTML = "";
-        }
+        try {
+            if (loader) {
+                loader.style.display = "flex";
+            }
+            if (mainContent) {
+                mainContent.style.display = "none";
+            }
+            if (container) {
+                container.innerHTML = "";
+            }
+            if (paginationContainer) {
+                paginationContainer.innerHTML = "";
+            }
 
-        const response = await fetch(VARIABLES_API_ENDPOINT);
-        const data = await response.json();
-        allData = data;
-        currentFilteredData = [...allData];
+            const response = await fetch(VARIABLES_API_ENDPOINT);
+            const data = await response.json();
+            allData = data;
+            currentFilteredData = [...allData];
+            currentPage = 1;
 
-        renderPage(currentFilteredData, currentPage);
-        setupPagination(currentFilteredData);
-        updateVariableCounter(allData.length);
+            renderPage(currentFilteredData, currentPage);
+            setupPagination(currentFilteredData);
+            updateVariableCounter(allData.length);
 
-        if (idPpParam) {
-            processSelect.value = `proc${idPpParam}`;
-            applyFilters();
-        }
-    } catch (error) {
-        console.error('Error al cargar los datos:', error);
-        container.innerHTML = "<p class='text-center text-danger'>Ocurrió un error al cargar los datos. Inténtalo nuevamente.</p>";
-    } finally {
-        if (loader) {
-            loader.style.display = "none";
-        }
-        if (mainContent) {
-            mainContent.style.display = "";
+            if (idPpParam) {
+                processSelect.value = `proc${idPpParam}`;
+                applyFilters();
+            }
+        } catch (error) {
+            console.error("Error al cargar los datos:", error);
+            if (container) {
+                container.innerHTML = "<p class='text-center text-danger'>Ocurrió un error al cargar los datos. Inténtalo nuevamente.</p>";
+            }
+        } finally {
+            if (loader) {
+                loader.style.display = "none";
+            }
+            if (mainContent) {
+                mainContent.style.display = "block";
+            }
         }
     }
-}
 
 // Buscar variables por término ingresado
 function searchVariables(term) {


### PR DESCRIPTION
## Summary
- add a new `/api/variables/extendidas` endpoint that merges database variables with the external indicator feed
- enrich the variable service with remote fetching, resilient parsing and configurable URL for the indicator source
- update the variables page JavaScript to consume the extended endpoint so the additional indicators appear alongside existing records

## Testing
- `./mvnw -q -DskipTests package` *(fails: Unable to download Maven binary in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d436a1ed948323ab4dde7735a2f795